### PR TITLE
Je finetune emoji module

### DIFF
--- a/scripts/JournalEntryForm/JournalEntryForm.js
+++ b/scripts/JournalEntryForm/JournalEntryForm.js
@@ -1,4 +1,4 @@
-import { getMoodEmoji, getDefaultMoodEmoji, getDefaultMoodValue } from '../utilities/moodEmojis.js';
+import { getMoodEmoji, getDefaultMoodEmoji, getDefaultMoodValue, getEmojisCount } from '../utilities/moodEmojis.js';
 
 document.addEventListener('input', event => {
   if(event.target.className === 'entry-form__mood') {
@@ -26,7 +26,7 @@ export const JournalEntryForm = () => {
         </fieldset>
         <fieldset class="form-group">
           <label for="mood" class="entry-form__label entry-form__mood-label">Mood</label>
-          <input type="range" class="entry-form__mood" id="mood" name="mood" vmin="0" max="9" step="1">
+          <input type="range" class="entry-form__mood" id="mood" name="mood" value="${getDefaultMoodValue()}" min="0" max="${getEmojisCount() - 1}" step="1">
         </fieldset>
         <p class="entry-form__mood-emoji">${getDefaultMoodEmoji()}</p>
       </div>

--- a/scripts/utilities/moodEmojis.js
+++ b/scripts/utilities/moodEmojis.js
@@ -14,3 +14,4 @@ export const getMoodEmoji = value => {
 
 export const getDefaultMoodEmoji = () => moodEmojis[DEFAULT_MOOD_VALUE];
 export const getDefaultMoodValue = () => DEFAULT_MOOD_VALUE;
+export const getEmojisCount = () => moodEmojis.length;

--- a/scripts/utilities/moodEmojis.js
+++ b/scripts/utilities/moodEmojis.js
@@ -3,7 +3,12 @@ const DEFAULT_MOOD_VALUE = 6;
 
 export const getMoodEmoji = value => {
   value = parseInt(value);
+
+  // verify that value is a number and is in the range of possible emojis
   if(isNaN(value)) return getDefaultMoodEmoji();
+  if(value > moodEmojis.length) value = moodEmojis.length - 1;
+  if(value < 0) value = 0;
+
   return moodEmojis[value];
 };
 

--- a/scripts/utilities/moodEmojis.js
+++ b/scripts/utilities/moodEmojis.js
@@ -1,6 +1,10 @@
 const moodEmojis = ['👿', '🤬', '😡', '😭', '😕', '🙃', '🙂', '😀', '😁', '🤠'];
 const DEFAULT_MOOD_VALUE = 6;
 
+/**
+ * Given a value, attempt to parse it as an integer and return the emoji corresponding to that integer index in the moodEmojis array.
+ * @param {any} value Value to get emoji for
+ */
 export const getMoodEmoji = value => {
   value = parseInt(value);
 
@@ -12,6 +16,17 @@ export const getMoodEmoji = value => {
   return moodEmojis[value];
 };
 
+/**
+ * Get the default mood emoji.
+ */
 export const getDefaultMoodEmoji = () => moodEmojis[DEFAULT_MOOD_VALUE];
+
+/**
+ * Get the integer mood value of the default mood emoji.
+ */
 export const getDefaultMoodValue = () => DEFAULT_MOOD_VALUE;
+
+/**
+ * Get the count of emojis in the moodEmojis array.
+ */
 export const getEmojisCount = () => moodEmojis.length;

--- a/scripts/utilities/moodEmojis.js
+++ b/scripts/utilities/moodEmojis.js
@@ -6,7 +6,7 @@ export const getMoodEmoji = value => {
 
   // verify that value is a number and is in the range of possible emojis
   if(isNaN(value)) return getDefaultMoodEmoji();
-  if(value > moodEmojis.length) value = moodEmojis.length - 1;
+  if(value >= moodEmojis.length) value = moodEmojis.length - 1;
   if(value < 0) value = 0;
 
   return moodEmojis[value];


### PR DESCRIPTION
1. Verify that `getMoodEmoji` function returns the last emoji in the array if a value greater than the last index of the array is passed in, and returns the first emoji in the array if a value less than 0 is passed in.
2. Verify that `JournalEntryForm.js` no longer hardcodes any assumptions about the emoji module - it now defines its range of emojis as being from `0` to `getEmojisCount() - 1`, and defaults to `getDefaultMoodValue()`.