### PR TITLE
Je fix past entries

### DIFF
--- a/scripts/JournalEntry/JournalEntryList.js
+++ b/scripts/JournalEntry/JournalEntryList.js
@@ -1,4 +1,4 @@
-import { getJournalEntries, useJournalEntries } from './JournalDataProvider.js';
+import { useJournalEntries } from './JournalDataProvider.js';
 import { JournalEntry } from './JournalEntry.js';
 
 const domNode = document.querySelector('.entries');

--- a/scripts/JournalEntry/JournalEntryList.js
+++ b/scripts/JournalEntry/JournalEntryList.js
@@ -13,9 +13,6 @@ const render = entries => {
 };
 
 export const JournalEntryList = () => {
-  getJournalEntries()
-    .then(() => {
-      const entries = useJournalEntries();
-      render(entries);
-    });
+  const entries = useJournalEntries();
+  render(entries);
 };

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,7 +1,12 @@
+import { getJournalEntries } from './JournalEntry/JournalDataProvider.js';
+
 import { JournalEntryForm } from './JournalEntryForm/JournalEntryForm.js';
 import { JournalEntryList } from './JournalEntry/JournalEntryList.js';
 import { JournalEntryNav } from './JournalEntryNav/JournalEntryNav.js';
 
 JournalEntryForm();
-JournalEntryList();
-JournalEntryNav();
+getJournalEntries()
+  .then(() => {
+    JournalEntryList();
+    JournalEntryNav();
+  });


### PR DESCRIPTION
1. Verify that the past entries nav is now loading.
1. Verify that, because both `JournalEntryList` and `JournalEntryNav` components depend on the collection of journal entries being loaded from the API, now neither component will render before that collection has succesfully loaded. This is accomplished by invoking these components in `main.js` only after calling `getJournalEntries`.