### PR TITLE
removed redundant api hits from daily journal noteStateChanged flow

### DIFF
--- a/scripts/JournalEntry/JournalEntryList.js
+++ b/scripts/JournalEntry/JournalEntryList.js
@@ -24,4 +24,4 @@ export const JournalEntryList = () => {
 /**
  * Event listener to update journal entry list on state changed.
  */
-eventHub.addEventListener('journalEntriesStateChanged', JournalEntryList);
+eventHub.addEventListener('journalEntriesStateChanged', () => render(useJournalEntries()));

--- a/scripts/JournalEntryNav/JournalEntryNav.js
+++ b/scripts/JournalEntryNav/JournalEntryNav.js
@@ -23,4 +23,4 @@ export const JournalEntryNav = () => {
     });
 };
 
-eventHub.addEventListener('journalEntriesStateChanged', JournalEntryNav);
+eventHub.addEventListener('journalEntriesStateChanged', () => render(useJournalEntriesReverseChronological()));


### PR DESCRIPTION
1. Verify that neither `JournalEntryList` nor `JournalEntryNav` are pinging the API in reaction to the `journalEntriesStateChanged` event.