### PR TITLE
Big Validator Refactor

### DIFF
--- a/scripts/JournalEntryForm/JournalEntryForm.js
+++ b/scripts/JournalEntryForm/JournalEntryForm.js
@@ -1,13 +1,11 @@
 import { JournalEntryFormError } from './JournalEntryFormError.js';
-import { JournalEntryFormValidator } from './JournalEntryFormValidator.js';
+import { validator } from './JournalEntryFormValidator.js';
 import { saveJournalEntry } from '../JournalEntry/JournalDataProvider.js';
 import { getMoodEmoji, getDefaultMoodEmoji, getDefaultMoodValue, getEmojisCount } from '../utilities/moodEmojis.js';
 import { getTodayDateString } from '../utilities/dateFormatting.js';
 
 const eventHub = document.querySelector('.container');
 const entryFormDOMNode = document.querySelector('#entry-form');
-
-const validator = new JournalEntryFormValidator();
 
 // will hold reference to DOM node containing mood emoji in form
 let moodEmojiContentTarget;

--- a/scripts/JournalEntryForm/JournalEntryForm.js
+++ b/scripts/JournalEntryForm/JournalEntryForm.js
@@ -7,9 +7,6 @@ import { getTodayDateString } from '../utilities/dateFormatting.js';
 const eventHub = document.querySelector('.container');
 const entryFormDOMNode = document.querySelector('#entry-form');
 
-// will hold reference to DOM node containing mood emoji in form
-let moodEmojiContentTarget;
-
 const defaults = {
   date: getTodayDateString(),
   concept: '',
@@ -65,16 +62,27 @@ const createJournalEntryObjectFromFormData = () => {
   }
 
   return journalEntry;
-}
+};
+
+/**
+ * Clear out all error messages from the DOM
+ */
+const clearErrorMessages = () => {
+  document
+    .querySelectorAll('.entry-form__errors')
+    .forEach(errorMessageNode => errorMessageNode.innerHTML = '');
+};
 
 /**
  * Render validation errors to the DOM.
- * @param {Object} errors Object of the form { name of input: [array of error messages for that input] }
+ * @param {Array} errors Array of error objects from the Validator.
  */
 const renderErrors = errors => {
-  Object.keys(errors).forEach(fieldName => {
-    const errorMessageNode = document.querySelector(`.entry-form__${fieldName}-errors`);
-    errorMessageNode.innerHTML = errors[fieldName].map(JournalEntryFormError).join('');
+  clearErrorMessages();
+
+  errors.forEach(error => {
+    const errorMessageNode = document.querySelector(`.entry-form__${error.propertyName}-errors`);
+    errorMessageNode.innerHTML += JournalEntryFormError(error.errorMessage);
   });
 };
 
@@ -88,29 +96,11 @@ const disableForm = () => {
 };
 
 /**
- * Reset entry form to default values for each input, re-enable inputs, and reset displayed mood emoji to its default.
- */
-const resetEntryForm = () => {
-  const { elements } = entryFormDOMNode;
-  for(const element of elements) {
-    element.disabled = false;
-    element.value = defaults[element.name];
-  }
-
-  moodEmojiContentTarget.innerHTML = getDefaultMoodEmoji();
-}
-
-/**
  * Event listener to update mood emoji rendered in form for mood input element.
  */
 eventHub.addEventListener('input', event => {
-
-  // grab reference to (dynamically created) mood emoji container if not already grabbed. this should only happen once, but should happen here b/c we can only be sure of its existence on the DOM once this runs.
-  if(!moodEmojiContentTarget) {
-    moodEmojiContentTarget = document.querySelector('.entry-form__mood-emoji');
-  }
-
   if(event.target.className === 'entry-form__mood') {
+    const moodEmojiContentTarget = document.querySelector('.entry-form__mood-emoji');
     moodEmojiContentTarget.innerHTML = getMoodEmoji(event.target.value);
   }
 });
@@ -125,11 +115,11 @@ eventHub.addEventListener('submit', event => {
 
     const journalEntry = createJournalEntryObjectFromFormData();
 
-    const { isValid, errors } = validator.validate(journalEntry);
+    const errors = validator.validate(journalEntry);
 
     renderErrors(errors);
 
-    if(isValid) {
+    if(errors.length === 0) {
       disableForm();
       saveJournalEntry(journalEntry);
     }
@@ -139,4 +129,4 @@ eventHub.addEventListener('submit', event => {
 /**
  * Event listener to re-render empty and enabled form after successful entry save.
  */
-eventHub.addEventListener('journalEntriesStateChanged', resetEntryForm);
+eventHub.addEventListener('journalEntriesStateChanged', render);

--- a/scripts/JournalEntryForm/JournalEntryFormValidator.js
+++ b/scripts/JournalEntryForm/JournalEntryFormValidator.js
@@ -1,84 +1,11 @@
+import { Validator } from '../utilities/Validator.js';
 import { isDateInThePast, isDateOnOrAfterCohortStartDate, isNotAboutBruceWillis, isNotEmpty } from '../utilities/validationFunctions.js';
 
-export class JournalEntryFormValidator {
-  fields = {
-    date: [
-      {
-        validator: isDateInThePast,
-        errorMessage: 'Date of entry cannot be in the future.'
-      },
-      {
-        validator: isDateOnOrAfterCohortStartDate,
-        errorMessage: 'I literally don\'t care about what you were doing before this class started.'
-      }
-    ],
-    concept: [
-      {
-        validator: isNotEmpty,
-        errorMessage: 'Concepts cannot be left blank.'
-      },
-      {
-        validator: isNotAboutBruceWillis,
-        errorMessage: 'Concepts covered cannot contain Bruce Willis, as this is a forbidden topic.'
-      }
-    ],
-    entry: [
-      {
-        validator: isNotEmpty,
-        errorMessage: 'Journal entry cannot be left blank.'
-      }
-    ]
-  }
+const validator = new Validator();
 
-  /**
-   * Return true if the last time this.validate was called on a journalEntry, all validation tests passed.
-   */
-  isValid = () => {
-    const fields = this.fields;
+validator.addValidatorToProperty(isDateInThePast, 'Date of entry cannot be in the future', 'date');
+validator.addValidatorToProperty(isDateOnOrAfterCohortStartDate, 'I literally don\'t care about what you were doing before this class started.', 'date');
+validator.addValidatorToProperty(isNotAboutBruceWillis, 'Text cannot contain a reference to Bruce Willis, as this is a forbidden topic.', 'concept', 'entry');
+validator.addValidatorToProperty(isNotEmpty, 'Field cannot be left blank', 'concept', 'entry');
 
-    for(const fieldName of Object.keys(fields)) {
-      for(const validationInfo of fields[fieldName]) {
-        if(!validationInfo.isValid) return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Get an object of the form { <fieldName>: [ array of error message strings for all errors detected for this field on last validate() ]}
-   */
-  getErrors = () => {
-    const fields = this.fields;
-    const errors = {};
-
-    Object.keys(fields).forEach(fieldName => {
-      errors[fieldName] = 
-        fields[fieldName]
-          .filter(validationInfo => !validationInfo.isValid)
-          .map(validationInfo => validationInfo.errorMessage);
-    });
-
-    return errors;
-  }
-
-  /**
-   * Given a journalEntry object, run all validator functions defined for each field of the object. 
-   * @param {Object} journalEntry The journal entry object that you want to validate.
-   * @returns Object of the form { isValid: <boolean value representing whether all tests were passed or not>, errors: { object mapping field names to array of error messages for detected errors for that field }}
-   */
-  validate = journalEntry => {
-    const fields = this.fields;
-
-    Object.keys(fields).forEach(fieldName => {
-      const journalEntryValueToValidate = journalEntry[fieldName];
-      fields[fieldName].forEach(validationInfo => {
-        validationInfo.isValid = validationInfo.validator(journalEntryValueToValidate);
-      });
-    });
-
-    return {
-      isValid: this.isValid(),
-      errors: this.getErrors()
-    };
-  }
-}
+export { validator };

--- a/scripts/utilities/Validator.js
+++ b/scripts/utilities/Validator.js
@@ -3,7 +3,6 @@ export class Validator {
   errors = []
 
   /**
-   * 
    * @param {function} validator The validator function to add 
    * @param {String} errorMessage The error message to set for this property's validation if the validator returns false
    * @param  {...any} propertyNames The property names that this validator should apply to

--- a/scripts/utilities/Validator.js
+++ b/scripts/utilities/Validator.js
@@ -1,0 +1,74 @@
+/**
+ * Class implementing various functions related to validating values of an object.
+ * Extend it to create a validator for an arbitrary type of object
+ */
+export class Validator {
+  propertiesToValidate = {}
+
+  /**
+   * 
+   * @param {function} validator The validator function to add 
+   * @param {String} errorMessage The error message to set for this property's validation if the validator returns false
+   * @param  {...any} propertyNames The property names that this validator should apply to
+   */
+  addValidatorToProperty = (validator, errorMessage, ...propertyNames) => {
+    propertyNames.forEach(propertyName => {
+      if(!this.propertiesToValidate[propertyName]) {
+        this.propertiesToValidate[propertyName] = [];
+      }
+      this.propertiesToValidate[propertyName].push({ validator, errorMessage });
+    });
+  }
+
+  /**
+   * Return true if the last time this.validate was called, all validation tests passed.
+   */
+  isValid = () => {
+    const properties = this.propertiesToValidate;
+
+    for(const propertyName of Object.keys(properties)) {
+      for(const validationInfo of properties[propertyName]) {
+        if(!validationInfo.isValid) return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Get an object of the form { <propertyName>: [ array of error message strings for all errors detected for this property on last validate() ]}
+   */
+  getErrors = () => {
+    const properties = this.propertiesToValidate;
+    const errors = {};
+
+    Object.keys(properties).forEach(propertyName => {
+      errors[propertyName] = 
+        properties[propertyName]
+          .filter(validationInfo => !validationInfo.isValid)
+          .map(validationInfo => validationInfo.errorMessage);
+    });
+
+    return errors;
+  }
+
+  /**
+   * Given an object, run all validator functions defined for each property of the object. 
+   * @param {Object} object The object that you want to validate.
+   * @returns Object of the form { isValid: <boolean value representing whether all tests were passed or not>, errors: { object mapping property names to array of error messages for detected errors for that property }}
+   */
+  validate = object => {
+    const properties = this.propertiesToValidate;
+
+    Object.keys(properties).forEach(propertyName => {
+      const valueToValidate = object[propertyName];
+      properties[propertyName].forEach(validationInfo => {
+        validationInfo.isValid = validationInfo.validator(valueToValidate);
+      });
+    });
+
+    return {
+      isValid: this.isValid(),
+      errors: this.getErrors()
+    };
+  }
+}

--- a/scripts/utilities/Validator.js
+++ b/scripts/utilities/Validator.js
@@ -1,9 +1,6 @@
-/**
- * Class implementing various functions related to validating values of an object.
- * Extend it to create a validator for an arbitrary type of object
- */
 export class Validator {
-  propertiesToValidate = {}
+  validators = []
+  errors = []
 
   /**
    * 
@@ -13,62 +10,27 @@ export class Validator {
    */
   addValidatorToProperty = (validator, errorMessage, ...propertyNames) => {
     propertyNames.forEach(propertyName => {
-      if(!this.propertiesToValidate[propertyName]) {
-        this.propertiesToValidate[propertyName] = [];
-      }
-      this.propertiesToValidate[propertyName].push({ validator, errorMessage });
+      const validationInfo = { propertyName, validator, errorMessage };
+      this.validators.push(validationInfo);
     });
-  }
-
-  /**
-   * Return true if the last time this.validate was called, all validation tests passed.
-   */
-  isValid = () => {
-    const properties = this.propertiesToValidate;
-
-    for(const propertyName of Object.keys(properties)) {
-      for(const validationInfo of properties[propertyName]) {
-        if(!validationInfo.isValid) return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Get an object of the form { <propertyName>: [ array of error message strings for all errors detected for this property on last validate() ]}
-   */
-  getErrors = () => {
-    const properties = this.propertiesToValidate;
-    const errors = {};
-
-    Object.keys(properties).forEach(propertyName => {
-      errors[propertyName] = 
-        properties[propertyName]
-          .filter(validationInfo => !validationInfo.isValid)
-          .map(validationInfo => validationInfo.errorMessage);
-    });
-
-    return errors;
   }
 
   /**
    * Given an object, run all validator functions defined for each property of the object. 
    * @param {Object} object The object that you want to validate.
-   * @returns Object of the form { isValid: <boolean value representing whether all tests were passed or not>, errors: { object mapping property names to array of error messages for detected errors for that property }}
+   * @returns {Array} Array of objects representing validations failed - each object will be of the form { propertyName {String}, errorMessage {String} }
    */
   validate = object => {
-    const properties = this.propertiesToValidate;
+    this.errors = [];
 
-    Object.keys(properties).forEach(propertyName => {
+    this.validators.forEach(validationInfo => {
+      const { propertyName, validator, errorMessage } = validationInfo;
       const valueToValidate = object[propertyName];
-      properties[propertyName].forEach(validationInfo => {
-        validationInfo.isValid = validationInfo.validator(valueToValidate);
-      });
+      if(!validator(valueToValidate)) {
+        this.errors.push({ propertyName, errorMessage });
+      }
     });
 
-    return {
-      isValid: this.isValid(),
-      errors: this.getErrors()
-    };
+    return this.errors.slice();
   }
 }


### PR DESCRIPTION
This was basically just a pretty large refactor of the validation strategy. I broke out a new and more generic `Validator` class that implements the logic of:
- keeping track of a list of validation steps (each an object, declaring which property name of an object to validate, which validation function to run on the value of that object at that property, and an error message to return if validation fails for that value)
- running all validation steps on a given object

This new `Validator` class also greatly simplified the logic of how I had previously written `JournalEntryFormValidator`

I then created a separate `JournalEntryFormValidator` module which just creates a new instance of a `Validator` and then sets the journal entry-specific validation steps for the validator, and then exports it for use in the `JournalEntryForm`.