### PR TITLE
validation functions use verb validate in name now

### DIFF
--- a/scripts/JournalEntryForm/JournalEntryFormValidator.js
+++ b/scripts/JournalEntryForm/JournalEntryFormValidator.js
@@ -1,11 +1,11 @@
 import { Validator } from '../utilities/Validator.js';
-import { isDateInThePast, isDateOnOrAfterCohortStartDate, isNotAboutBruceWillis, isNotEmpty } from '../utilities/validationFunctions.js';
+import { validateDateIsNotInTheFuture, validateDateIsOnOrAfterCohortStartDate, validateIsNotAboutBruceWillis, validateIsNotEmpty } from '../utilities/validationFunctions.js';
 
 const validator = new Validator();
 
-validator.addValidatorToProperty(isDateInThePast, 'Date of entry cannot be in the future', 'date');
-validator.addValidatorToProperty(isDateOnOrAfterCohortStartDate, 'I literally don\'t care about what you were doing before this class started.', 'date');
-validator.addValidatorToProperty(isNotAboutBruceWillis, 'Text cannot contain a reference to Bruce Willis, as this is a forbidden topic.', 'concept', 'entry');
-validator.addValidatorToProperty(isNotEmpty, 'Field cannot be left blank', 'concept', 'entry');
+validator.addValidatorToProperty(validateDateIsNotInTheFuture, 'Date of entry cannot be in the future', 'date');
+validator.addValidatorToProperty(validateDateIsOnOrAfterCohortStartDate, 'I literally don\'t care about what you were doing before this class started.', 'date');
+validator.addValidatorToProperty(validateIsNotAboutBruceWillis, 'Text cannot contain a reference to Bruce Willis, as this is a forbidden topic.', 'concept', 'entry');
+validator.addValidatorToProperty(validateIsNotEmpty, 'Field cannot be left blank', 'concept', 'entry');
 
 export { validator };

--- a/scripts/utilities/validationFunctions.js
+++ b/scripts/utilities/validationFunctions.js
@@ -1,9 +1,9 @@
 const COHORT_START_DATE_TIMESTAMP = Date.parse('2020-07-06');
 
-export const isDateInThePast = date => Date.parse(date) - Date.now() <= 0;
+export const validateDateIsNotInTheFuture = date => Date.parse(date) - Date.now() <= 0;
 
-export const isDateOnOrAfterCohortStartDate = date => COHORT_START_DATE_TIMESTAMP - Date.parse(date) <= 0;
+export const validateDateIsOnOrAfterCohortStartDate = date => COHORT_START_DATE_TIMESTAMP - Date.parse(date) <= 0;
 
-export const isNotAboutBruceWillis = value => !(value.toLowerCase().includes('bruce willis'));
+export const validateIsNotAboutBruceWillis = value => !(value.toLowerCase().includes('bruce willis'));
 
-export const isNotEmpty = value => value.toString().trim().length > 0;
+export const validateIsNotEmpty = value => value.toString().trim().length > 0;


### PR DESCRIPTION
Changed validation functions to start with a verb `validate`. They used to just start with `is` which sounds more like a boolean property than a boolean-returning function name.