### PR TITLE
Je cleanup and reduce api hits

### DIFF
--- a/scripts/Concepts/ConceptProvider.js
+++ b/scripts/Concepts/ConceptProvider.js
@@ -2,19 +2,32 @@ let concepts = [];
 
 const eventHub = document.querySelector('.container');
 
+/**
+ * Broadcast an event indicating the application state concepts has changed
+ */
 const broadcastConceptsStateChanged = () => {
   const conceptsStateChanged = new CustomEvent('conceptsStateChanged');
   eventHub.dispatchEvent(conceptsStateChanged);
 };
 
+/**
+ * Returns a copy of the concepts application state array
+ */
 export const useConcepts = () => concepts.slice();
 
+/**
+ * GET concepts from API
+ */
 export const getConcepts = () => {
   return fetch ('http://localhost:8088/concepts')
     .then(res => res.json())
     .then(conceptsData => concepts = conceptsData);
 };
 
+/**
+ * Given a concept name string, POST a new concept object to the database with that name.
+ * @param {String} conceptName The concept name to create a new concept object for
+ */
 const saveConcept = conceptName => {
   const conceptObj = { name: conceptName };
 
@@ -27,10 +40,18 @@ const saveConcept = conceptName => {
   });
 }
 
+/**
+ * Given an array of concept name strings, determine which concept names are not already reflected by concept objects in the database, create new concept objects in the database for each of those names, and then return array of concept objects for each concept name string in the array passed in as argument.
+ * @param {Array} conceptNames Array of strings representing concept names
+ */
 export const getOrCreateConcepts = conceptNames => {
   const conceptsToCreate = conceptNames.filter(conceptString => 
     !(concepts.some(concept => concept.name === conceptString))
   );
+
+  if(!conceptsToCreate.length) {
+    return Promise.resolve(concepts.filter(concept => conceptNames.includes(concept.name)));
+  }
 
   return Promise.all(conceptsToCreate.map(saveConcept))
     .then(getConcepts)

--- a/scripts/Concepts/EntryConceptProvider.js
+++ b/scripts/Concepts/EntryConceptProvider.js
@@ -4,11 +4,19 @@ let entryConcepts = [];
 
 const eventHub = document.querySelector('.container');
 
+/**
+ * Broadcast event announcing there is a new entryConcepts state
+ */
 const broadcastEntryConceptsStateChanged = () => {
   const entryConceptsStateChanged = new CustomEvent('entryConceptsStateChanged');
   eventHub.dispatchEvent(entryConceptsStateChanged);
 };
 
+/**
+ * POST a new entryConcept to the API
+ * @param {Object} entry The journal entry object to create a new entryConcept object for
+ * @param {Object} concept The concept object to create a new entryConcept object for
+ */
 const saveEntryConcept = (entry, concept) => {
   const entryConcept = {
     entryId: entry.id,
@@ -24,48 +32,82 @@ const saveEntryConcept = (entry, concept) => {
   });
 }
 
-const deleteEntryConcept = id => {
-  return fetch(`http://localhost:8088/entryConcepts/${id}`, {
-    method: 'DELETE'
-  });
-}
-
-export const useEntryConcepts = () => entryConcepts.slice();
-
+/**
+ * GET entryConcepts from API
+ */
 export const getEntryConcepts = () => {
   return fetch ('http://localhost:8088/entryConcepts')
     .then(res => res.json())
     .then(entryConceptsData => entryConcepts = entryConceptsData);
 };
 
-export const saveEntryConcepts = (entry, concepts) => {
-  return getOrCreateConcepts(concepts)
-    .then(conceptObjects => Promise.all(conceptObjects.map(concept => saveEntryConcept(entry, concept))))
+/**
+ * Returns a copy of the entryConcepts application state array.
+ */
+export const useEntryConcepts = () => entryConcepts.slice();
+
+/**
+ * DELETE an entryConcept by ID
+ * @param {Number} id The ID of the entryConcept to delete
+ */
+const deleteEntryConcept = id => {
+  return fetch(`http://localhost:8088/entryConcepts/${id}`, {
+    method: 'DELETE'
+  });
+};
+
+/**
+ * Given a journal entry ID, delete all entryConcept objects in the database referencing that entryId.
+ * @param {int} id ID of the journal entry
+ */
+export const deleteEntryConceptsForEntry = id => {
+  const entryConceptsToDelete = entryConcepts.filter(entryConcept => entryConcept.entryId === id);
+
+  return Promise.all(entryConceptsToDelete.map(entryConcept => deleteEntryConcept(entryConcept.id)))
     .then(getEntryConcepts)
     .then(broadcastEntryConceptsStateChanged);
 }
 
+/**
+ * Given a journal entry object and an array of conceptName strings representing all concepts that should be associated with this journal entry:
+ *  1) Transform the array of concept name strings into an array of Concept objects, creating new Concept objects in the database where necessary
+ *  2) Create and save to database all new entryConcept objects representing new concepts that are to be associated with this journal entry
+ *  3) Delete all entryConcept objects in the database that representing entry-concept relationships that no longer exist
+ * @param {Object} entry The journal entry object to update entryConcepts for
+ * @param {Array} concepts Array of conceptName strings to be associated with this entry
+ */
 export const updateEntryConcepts = (entry, concepts) => {
   let conceptObjects;
 
   return getOrCreateConcepts(concepts)
     .then(conceptData => conceptObjects = conceptData)
-    .then(() => identifyNewConceptsForEntry(entry, conceptObjects))
-    .then(newConcepts => Promise.all(newConcepts.map(concept => saveEntryConcept(entry, concept))))
+    .then(() => saveNewEntryConceptsForEntry(entry, conceptObjects))
     .then(() => deleteUnusedEntryConcepts(entry, conceptObjects))
     .then(getEntryConcepts)
     .then(broadcastEntryConceptsStateChanged);
 }
 
-const identifyNewConceptsForEntry = (entry, concepts) => {
+/**
+ * Given a journal entry object and an array of concept objects representing all concepts associated with this journal entry, create and save new entryConcept objects in the database for each concept in the concepts array that is not already associated with this journal entry in an entryConcept object.
+ * @param {Object} entry The Journal Entry object to potentially save new entryconcepts for
+ * @param {Array} concepts Array of Concept objects that are associated with this entry
+ */
+const saveNewEntryConceptsForEntry = (entry, concepts) => {
   const entryConceptsForEntry = entryConcepts
     .filter(entryConcept => entryConcept.entryId === entry.id);
 
-  return concepts.filter(concept => 
+  const newConcepts = concepts.filter(concept => 
     !(entryConceptsForEntry.some(entryConcept => entryConcept.conceptId === concept.id))
   );
+
+  return Promise.all(newConcepts.map(concept => saveEntryConcept(entry, concept)));
 }
 
+/**
+ * Given a journal entry object and an array of concept objects representing all concepts associated with this journal entry, delete all entryConcept objects currently saved in the database that refer to this entryId but refer to conceptIds that are not present in the supplied concepts array.
+ * @param {Object} entry The journal entry to potentially delete entryConcepts for
+ * @param {Array} concepts Array of Concept objects that are associated with this entry
+ */
 const deleteUnusedEntryConcepts = (entry, concepts) => {
   const unusedEntryConcepts = entryConcepts
     .filter(entryConcept => entryConcept.entryId === entry.id)
@@ -74,10 +116,3 @@ const deleteUnusedEntryConcepts = (entry, concepts) => {
   return Promise.all(unusedEntryConcepts.map(entryConcept => deleteEntryConcept(entryConcept.id)));
 }
 
-export const deleteEntryConceptsForEntry = id => {
-  const entryConceptsToDelete = entryConcepts.filter(entryConcept => entryConcept.entryId === id);
-
-  return Promise.all(entryConceptsToDelete.map(entryConcept => deleteEntryConcept(entryConcept.id)))
-    .then(getEntryConcepts)
-    .then(broadcastEntryConceptsStateChanged);
-}

--- a/scripts/JournalEntry/JournalDataProvider.js
+++ b/scripts/JournalEntry/JournalDataProvider.js
@@ -1,4 +1,4 @@
-import { saveEntryConcepts, updateEntryConcepts, deleteEntryConceptsForEntry } from '../Concepts/EntryConceptProvider.js';
+import { updateEntryConcepts, deleteEntryConceptsForEntry } from '../Concepts/EntryConceptProvider.js';
 
 const JOURNAL_ENTRY_FIELDS = [ 'id', 'date', 'moodId', 'entry' ];
 
@@ -51,7 +51,7 @@ export const saveJournalEntry = entry => {
     body: JSON.stringify(createSaveableJournalEntryObject(entry))
   })
     .then(res => res.json())
-    .then(entryData => saveEntryConcepts(entryData, entry.concepts))
+    .then(entryData => updateEntryConcepts(entryData, entry.concepts))
     .then(getJournalEntries)
     .then(broadcastJournalEntriesStateChanged);
 };

--- a/scripts/JournalEntry/JournalDataProvider.js
+++ b/scripts/JournalEntry/JournalDataProvider.js
@@ -6,6 +6,9 @@ let journal = [];
 
 const eventHub = document.querySelector('.container');
 
+/**
+ * Broadcast an event indicating the the application state of journal entries has changed.
+ */
 const broadcastJournalEntriesStateChanged = () => {
   const journalEntriesStateChanged = new CustomEvent('journalEntriesStateChanged');
   eventHub.dispatchEvent(journalEntriesStateChanged);
@@ -22,12 +25,18 @@ const createSaveableJournalEntryObject = journalEntry => {
   }, {});
 };
 
+/**
+ * GET journal entries from API.
+ */
 export const getJournalEntries = () => {
   return fetch('http://localhost:8088/entries?_expand=mood')
     .then(res => res.json())
     .then(journalData => journal = journalData);
 };
 
+/**
+ * Returns a copy of all journal entries.
+ */
 export const useJournalEntries = () => {
   const sortedByDate = journal.sort(
     (currentEntry, nextEntry) => Date.parse(currentEntry.date) - Date.parse(nextEntry.date)
@@ -35,6 +44,9 @@ export const useJournalEntries = () => {
   return JSON.parse(JSON.stringify(sortedByDate));
 };
 
+/**
+ * Returns a copy of all journal entries, sorted reverse chronologically.
+ */
 export const useJournalEntriesReverseChronological = () => {
   const sortedReverseChronological = journal.sort(
     (currentEntry, nextEntry) => Date.parse(nextEntry.date) - Date.parse(currentEntry.date)
@@ -42,6 +54,10 @@ export const useJournalEntriesReverseChronological = () => {
   return JSON.parse(JSON.stringify(sortedReverseChronological));
 };
 
+/**
+ * Given an entry object, create a new entry object in the database such that its values are equal to the values of the entry object passed-in as argument. Also create new entryConcept objects for this entry object - the .concepts property of the entry argument should hold array of strings of concept names for this entry.
+ * @param {Object} entry An object representing the new values to save for the entry.
+ */
 export const saveJournalEntry = entry => {
   fetch('http://localhost:8088/entries', {
     method: 'POST',
@@ -56,6 +72,10 @@ export const saveJournalEntry = entry => {
     .then(broadcastJournalEntriesStateChanged);
 };
 
+/**
+ * Given an entry object with id property, update the entry object in the database with that ID such that its values are equal to the values of the entry object passed-in as argument. Also update the entryConcept objects associated with this entry object - the .concepts property of the entry argument should hold array of strings of concept names for this entry.
+ * @param {Object} entry An object representing the new values to save for the entry.
+ */
 export const updateJournalEntry = entry => {
   const { id } = entry;
   fetch(`http://localhost:8088/entries/${id}` ,{
@@ -71,6 +91,10 @@ export const updateJournalEntry = entry => {
     .then(broadcastJournalEntriesStateChanged);
 };
 
+/**
+ * Delete a journal entry from database. Will also delete all entryConcept objects with this entry ID.
+ * @param {Number} id The ID of the journal entry to delete
+ */
 export const deleteJournalEntry = id => {
   fetch(`http://localhost:8088/entries/${id}`, {
     method: 'DELETE'

--- a/scripts/JournalEntry/JournalEntryList.js
+++ b/scripts/JournalEntry/JournalEntryList.js
@@ -15,6 +15,7 @@ let concepts = [];
 let entryConcepts = [];
 
 const render = () => {
+  // attach array of entryConcepts for each entry to entry.concepts
   entries.forEach(entry => {
     entry.concepts = entryConcepts
       .filter(entryConcept => entryConcept.entryId === entry.id)

--- a/scripts/JournalEntryForm/JournalEntryForm.js
+++ b/scripts/JournalEntryForm/JournalEntryForm.js
@@ -11,15 +11,20 @@ import { saveJournalEntry, updateJournalEntry } from '../JournalEntry/JournalDat
 const eventHub = document.querySelector('.container');
 
 /**
- * Render a Journal Entry Form directly to the DOM node with class .entry-form-container
+ * JournalEntryForm component to render directly to the DOM
  */
 export const JournalEntryForm = () => {
   getMoods()
-    .then(() => {
-      document
-        .querySelector('.entry-form-container')
-        .innerHTML = JournalEntryFormHTML();
-    })
+    .then(render);
+};
+
+/**
+ * Render directly to the DOM node with class .entry-form-container
+ */
+export const render = () => {
+  document
+    .querySelector('.entry-form-container')
+    .innerHTML = JournalEntryFormHTML();
 };
 
 /**
@@ -126,4 +131,4 @@ eventHub.addEventListener('submit', event => {
 /**
  * Event listener to re-render empty and enabled form after successful entry save.
  */
-eventHub.addEventListener('journalEntriesStateChanged', JournalEntryForm);
+eventHub.addEventListener('journalEntriesStateChanged', render);

--- a/scripts/JournalEntryForm/JournalEntryFormValidator.js
+++ b/scripts/JournalEntryForm/JournalEntryFormValidator.js
@@ -1,5 +1,5 @@
 import { Validator } from '../utilities/Validator.js';
-import { validateDateIsNotInTheFuture, validateDateIsOnOrAfterCohortStartDate, validateIsNotAboutBruceWillis, validateIsNotEmpty, validateMoodIsNotWorstPossible, validateIsNotEmptyArray, validateArrayDoesNotContainDuplicates } from '../utilities/validationFunctions.js';
+import { validateDateIsNotInTheFuture, validateDateIsOnOrAfterCohortStartDate, validateIsNotAboutBruceWillis, validateIsNotEmpty, validateMoodIsNotWorstPossible, validateIsNotEmptyArray, validateArrayDoesNotContainDuplicates, validateArrayLengthIsNotGreaterThanThree } from '../utilities/validationFunctions.js';
 
 const validator = new Validator();
 
@@ -8,7 +8,8 @@ validator.addValidatorToProperty(validateDateIsOnOrAfterCohortStartDate, 'I lite
 validator.addValidatorToProperty(validateIsNotAboutBruceWillis, 'Text cannot contain a reference to Bruce Willis, as this is a forbidden topic.', 'entry');
 validator.addValidatorToProperty(validateIsNotEmpty, 'Field cannot be left blank.', 'entry');
 validator.addValidatorToProperty(validateIsNotEmptyArray, 'Field cannot be left blank.', 'concepts');
-validator.addValidatorToProperty(validateArrayDoesNotContainDuplicates, 'List of concepts covered cannot contain duplicates', 'concepts');
+validator.addValidatorToProperty(validateArrayDoesNotContainDuplicates, 'List of concepts covered cannot contain duplicates.', 'concepts');
+validator.addValidatorToProperty(validateArrayLengthIsNotGreaterThanThree, 'Sorry but you you can only tag a post with up to three concepts.', 'concepts');
 validator.addValidatorToProperty(validateMoodIsNotWorstPossible, 'Come on, surely you didn\'t have THAT bad of a day, cowpoke.', 'moodId');
 
 export { validator };

--- a/scripts/utilities/validationFunctions.js
+++ b/scripts/utilities/validationFunctions.js
@@ -12,6 +12,8 @@ export const validateIsNotEmpty = value => value.toString().trim().length > 0;
 
 export const validateIsNotEmptyArray = value => value.filter(value => value.trim()).length > 0;
 
+export const validateArrayLengthIsNotGreaterThanThree = array => array.length <= 3;
+
 export const validateArrayDoesNotContainDuplicates = array => {
   const set = new Set(array);
   return set.size === array.length;


### PR DESCRIPTION
Wiped out a couple API hits that didn't need to happen, heavily commented all of the data providers, added a new validation to the form that only up to three concept-tags are allowed per entry, made both saveJournalEntry and updateJournalEntry use the same updateEntryConcepts function instead of having separate saveEntryConcepts and updateEntryConcepts functions (since the functionality of saveEntryConcepts is just a subset of the functionality of updateEntryConcepts).