### PR TITLE
validation check added to ensure concept name of empty string cannot …

### DIFF
--- a/api/entries.json
+++ b/api/entries.json
@@ -52,47 +52,6 @@
       "label": "🤠"
     }
   ],
-  "concepts": [
-    {
-      "name": "a",
-      "id": 1
-    },
-    {
-      "name": "b",
-      "id": 2
-    },
-    {
-      "name": "c",
-      "id": 3
-    },
-    {
-      "name": "d",
-      "id": 4
-    },
-    {
-      "name": "e",
-      "id": 5
-    },
-    {
-      "name": "test",
-      "id": 6
-    },
-    {
-      "name": "and another test",
-      "id": 7
-    },
-    {
-      "name": "apis",
-      "id": 8
-    },
-    {
-      "name": "javasript",
-      "id": 9
-    },
-    {
-      "name": "javascript",
-      "id": 10
-    }
-  ],
+  "concepts": [],
   "entryConcepts": []
 }

--- a/scripts/JournalEntryForm/JournalEntryFormValidator.js
+++ b/scripts/JournalEntryForm/JournalEntryFormValidator.js
@@ -1,5 +1,5 @@
 import { Validator } from '../utilities/Validator.js';
-import { validateDateIsNotInTheFuture, validateDateIsOnOrAfterCohortStartDate, validateIsNotAboutBruceWillis, validateIsNotEmpty, validateMoodIsNotWorstPossible, validateIsNotEmptyArray, validateArrayDoesNotContainDuplicates, validateArrayLengthIsNotGreaterThanThree } from '../utilities/validationFunctions.js';
+import { validateDateIsNotInTheFuture, validateDateIsOnOrAfterCohortStartDate, validateIsNotAboutBruceWillis, validateIsNotEmpty, validateMoodIsNotWorstPossible, validateIsNotEmptyArray, validateArrayDoesNotContainDuplicates, validateArrayLengthIsNotGreaterThanThree, validateArrayContainsNoEmptyValues } from '../utilities/validationFunctions.js';
 
 const validator = new Validator();
 
@@ -10,6 +10,7 @@ validator.addValidatorToProperty(validateIsNotEmpty, 'Field cannot be left blank
 validator.addValidatorToProperty(validateIsNotEmptyArray, 'Field cannot be left blank.', 'concepts');
 validator.addValidatorToProperty(validateArrayDoesNotContainDuplicates, 'List of concepts covered cannot contain duplicates.', 'concepts');
 validator.addValidatorToProperty(validateArrayLengthIsNotGreaterThanThree, 'Sorry but you you can only tag a post with up to three concepts.', 'concepts');
+validator.addValidatorToProperty(validateArrayContainsNoEmptyValues, 'You cannot submit a blank value as a concept.', 'concepts');
 validator.addValidatorToProperty(validateMoodIsNotWorstPossible, 'Come on, surely you didn\'t have THAT bad of a day, cowpoke.', 'moodId');
 
 export { validator };

--- a/scripts/utilities/validationFunctions.js
+++ b/scripts/utilities/validationFunctions.js
@@ -10,9 +10,11 @@ export const validateIsNotAboutBruceWillis = value => !(value.toLowerCase().incl
 
 export const validateIsNotEmpty = value => value.toString().trim().length > 0;
 
-export const validateIsNotEmptyArray = value => value.filter(value => value.trim()).length > 0;
+export const validateIsNotEmptyArray = array => array.length > 0;
 
 export const validateArrayLengthIsNotGreaterThanThree = array => array.length <= 3;
+
+export const validateArrayContainsNoEmptyValues = array => array.every(el => el.trim());
 
 export const validateArrayDoesNotContainDuplicates = array => {
   const set = new Set(array);


### PR DESCRIPTION
1. Verify that you cannot successfully create or edit a journal entry if you provide an empty string as any of the concept values you provide (e.g., `a, , b` should fail validation for this reason).